### PR TITLE
Let the user define the timestamp to use for testing purposes.

### DIFF
--- a/requests_hawk/__init__.py
+++ b/requests_hawk/__init__.py
@@ -37,7 +37,8 @@ class HawkAuth(AuthBase):
     exclusive.  You should set one or the other.
 
     """
-    def __init__(self, hawk_session=None, credentials=None, server_url=None):
+    def __init__(self, hawk_session=None, credentials=None, server_url=None,
+                 _timestamp=None):
         if ((credentials, hawk_session) == (None, None)
                 or (credentials is not None and hawk_session is not None)):
             raise AttributeError("You should pass either 'hawk_session' "
@@ -56,6 +57,7 @@ class HawkAuth(AuthBase):
                 'algorithm': 'sha256'
             }
         self.credentials = credentials
+        self._timestamp = _timestamp
 
         if server_url is not None:
             self.host = urlparse(server_url).netloc
@@ -71,7 +73,8 @@ class HawkAuth(AuthBase):
             r.url,
             r.method,
             content=r.body or '',
-            content_type=r.headers.get('Content-Type', '')
+            content_type=r.headers.get('Content-Type', ''),
+            _timestamp=self._timestamp
         )
 
         r.headers['Authorization'] = sender.request_header

--- a/requests_hawk/tests/test_hawkauth.py
+++ b/requests_hawk/tests/test_hawkauth.py
@@ -29,3 +29,17 @@ class TestHawkAuth(unittest.TestCase):
         auth = HawkAuth(hawk_session=codecs.encode(b"hello", "hex_codec"),
                         server_url="http://localhost:5000")
         self.assertEquals(auth.host, "localhost:5000")
+
+    def test_hawk_auth_can_handle_a_timestamp_argument(self):
+        auth = HawkAuth(hawk_session=codecs.encode(b"hello", "hex_codec"),
+                        _timestamp=1431698847)
+
+        class Request(object):
+            method = 'GET'
+            body = ''
+            url = 'http://www.example.com'
+            headers = {'Content-Type': 'application/json'}
+
+        r = auth(Request())
+        self.assertTrue('ts="1431698847"' in r.headers['Authorization'],
+                        "Timestamp doesn't match")


### PR DESCRIPTION
This is a mohawk feature that I want to use with requests-hawk in order to test the Stale Timestamp behavior using loads.

See https://github.com/kumar303/mohawk/blob/master/mohawk/sender.py#L96