### PR TITLE
Handle request json= parameter

### DIFF
--- a/requests_hawk/tests/test_hawkauth.py
+++ b/requests_hawk/tests/test_hawkauth.py
@@ -48,9 +48,7 @@ class TestHawkAuth(unittest.TestCase):
         auth = HawkAuth(hawk_session=codecs.encode(b"hello", "hex_codec"),
                         _timestamp=1431698847)
 
-        # XXX kennethreitz/requests#3948a9562db886e7ead6a48dbcbada34fbeb0838 is
-        # XXX needed in order to remove the ``data={}`` parameter in this test.
-        request = Request('PUT', 'http://www.example.com', data={},
+        request = Request('PUT', 'http://www.example.com',
                           json={"foo": "bar"}, auth=auth)
         r = request.prepare()
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with codecs.open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
 with codecs.open(os.path.join(here, 'CHANGES.txt'), encoding='utf-8') as f:
     CHANGES = f.read()
 
-requires = ['requests', 'mohawk']
+requires = ['requests>=2.8.1', 'mohawk']
 
 setup(name='requests-hawk',
       version='0.3.0.dev0',


### PR DESCRIPTION
I don't know why, put it looks like requests-hawk doesn't work with:

    request.put(url, json={"data": {}}, auth=Hawk())

The body in that case is None.