### PR TITLE
Relax the requests package version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with codecs.open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
 with codecs.open(os.path.join(here, 'CHANGES.txt'), encoding='utf-8') as f:
     CHANGES = f.read()
 
-requires = ['requests>=2.8.1', 'mohawk']
+requires = ['requests!=2.8.0', 'mohawk']
 
 setup(name='requests-hawk',
       version='0.3.0.dev0',


### PR DESCRIPTION
The only version that is broken is 2.8.0, so this switches to blacklisting that specifically rather than requiring >=2.8.1, since 2.7.x et al are perfectly fine, and setup.py `requires` is meant to be as generic as possible:
http://python-packaging-user-guide.readthedocs.org/en/latest/requirements/#install-requires