### PR TITLE
Switch to the faster container-based Travis infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+# Use the newer/faster container-based Travis infrastructure
+sudo: false
 language: python
 python: 2.7
 env:


### PR DESCRIPTION
By declaring that the tests do not require `sudo`, Travis can run the test jobs on their newer/faster container-based infrastructure:
https://docs.travis-ci.com/user/migrating-from-legacy/

(Notably the builds start within seconds rather than needing to wait for the VMs to be spun up before the test run even starts)