### PR TITLE
Simplify the API for using HawkAuth when the id and key are known

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,10 +1,14 @@
 CHANGELOG
 =========
 
-0.3.0 (unreleased)
+1.0.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Simplified API for using HawkAuth when the id and key are known. (#8)
+- Added support for overriding the default algorithm (sha256) when deriving
+  credentials from the hawk session token, via a new ``algorithm`` parameter.
+
+See the README for migration advice if you use the ``credentials`` parameter.
 
 
 0.2.1 (2015-10-14)

--- a/README.rst
+++ b/README.rst
@@ -29,12 +29,7 @@ Then, in your project, if you know the `id` and `key`, you can use::
     import requests
     from requests_hawk import HawkAuth
 
-    credentials = {
-        'id': 'my-hawk-id',
-        'key': 'my-hawk-secret-key',
-        'algorithm': 'sha256'
-    }
-    hawk_auth = HawkAuth(credentials=credentials)
+    hawk_auth = HawkAuth(id='my-hawk-id', key='my-hawk-secret-key')
     requests.post("https://example.com/url", auth=hawk_auth)
 
 Or if you need to derive them from the hawk session token, instead use::
@@ -52,6 +47,12 @@ Or if you need to derive them from the hawk session token, instead use::
 
 In the second example, the ``server_url`` parameter to ``HawkAuth`` was used to
 provide a default host name, to avoid having to repeat it for each request.
+
+If you wish to override the default algorithm of ``sha256``, pass the desired
+algorithm name using the optional ``algorithm`` parameter.
+
+Note: The ``credentials`` parameter has been removed. Instead pass ``id`` and
+``key`` separately (as above), or pass the existing dict as ``**credentials``.
 
 Integration with httpie
 =======================

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ This project allows you to use `the python requests library
 
 Hawk itself does not provide any mechanism for obtaining or transmitting the
 set of shared credentials required, but this project proposes a scheme we use
-accross mozilla services projects.
+across mozilla services projects.
 
 Great, how can I use it?
 ========================
@@ -59,12 +59,12 @@ Okay, on to the actual details.
 The server gives you a session token, that you'll need to derive to get the
 hawk credentials.
 
-Do an HKDF derivation on the given session token. You’ll need to use the
+Do an HKDF derivation on the given session token. You'll need to use the
 following parameters::
 
     key_material = HKDF(hawk_session, '', 'identity.mozilla.com/picl/v1/sessionToken', 32*2)
 
-The key material you’ll get out of the HKDF needs to be separated into two
+The key material you'll get out of the HKDF needs to be separated into two
 parts, the first 32 hex characters are the ``hawk id``, and the next 32 ones are the
 ``hawk key``::
 

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,22 @@ First, you'll need to install it::
 
     pip install requests-hawk
 
-Then, in your project, you can use it like that::
+Then, in your project, if you know the `id` and `key`, you can use::
+
+  .. code-block:: python
+
+    import requests
+    from requests_hawk import HawkAuth
+
+    credentials = {
+        'id': 'my-hawk-id',
+        'key': 'my-hawk-secret-key',
+        'algorithm': 'sha256'
+    }
+    hawk_auth = HawkAuth(credentials=credentials)
+    requests.post("https://example.com/url", auth=hawk_auth)
+
+Or if you need to derive them from the hawk session token, instead use::
 
   .. code-block:: python
 
@@ -34,6 +49,9 @@ Then, in your project, you can use it like that::
         server_url=self.server_url
     )
     requests.post("/url", auth=hawk_auth)
+
+In the second example, the ``server_url`` parameter to ``HawkAuth`` was used to
+provide a default host name, to avoid having to repeat it for each request.
 
 Integration with httpie
 =======================

--- a/README.rst
+++ b/README.rst
@@ -18,9 +18,13 @@ Great, how can I use it?
 
 First, you'll need to install it::
 
+  .. code-block:: bash
+
     pip install requests-hawk
 
 Then, in your project, you can use it like that::
+
+  .. code-block:: python
 
     import requests
     from requests_hawk import HawkAuth
@@ -40,10 +44,14 @@ uses the requests library. We've made it simple for you to plug hawk with it.
 
 If you know the id and key, use it like that::
 
+  .. code-block:: bash
+
    http POST localhost:5000/registration\
    --auth-type=hawk --auth='id:key'
 
 Or, if you want to use the hawk session token, you can do as follows::
+
+  .. code-block:: bash
 
    http POST localhost:5000/registration\
    --auth-type=hawk --auth='c0d8cd2ec579a3599bef60f060412f01f5dc46f90465f42b5c47467481315f51:'
@@ -62,11 +70,15 @@ hawk credentials.
 Do an HKDF derivation on the given session token. You'll need to use the
 following parameters::
 
+  .. code-block:: python
+
     key_material = HKDF(hawk_session, '', 'identity.mozilla.com/picl/v1/sessionToken', 32*2)
 
 The key material you'll get out of the HKDF needs to be separated into two
 parts, the first 32 hex characters are the ``hawk id``, and the next 32 ones are the
 ``hawk key``::
+
+  .. code-block:: python
 
     credentials = {
         'id': keyMaterial[0:32]
@@ -78,5 +90,7 @@ Run tests
 =========
 
 To run test, you can use tox::
+
+  .. code-block:: bash
 
     tox

--- a/requests_hawk/__init__.py
+++ b/requests_hawk/__init__.py
@@ -54,11 +54,7 @@ class HawkAuth(AuthBase):
             }
         self.credentials = credentials
         self._timestamp = _timestamp
-
-        if server_url is not None:
-            self.host = urlparse(server_url).netloc
-        else:
-            self.host = None
+        self.host = urlparse(server_url).netloc if server_url else None
 
     def __call__(self, r):
         if self.host is not None:

--- a/requests_hawk/__init__.py
+++ b/requests_hawk/__init__.py
@@ -120,16 +120,14 @@ try:
         description = ''
 
         def get_auth(self, username, password):
-            kwargs = {}
             if password == '':
-                kwargs['hawk_session'] = username
-            else:
-                kwargs['credentials'] = {
-                    'id': username,
-                    'key': password,
-                    'algorithm': 'sha256'
-                }
-            return HawkAuth(**kwargs)
+                return HawkAuth(hawk_session=username)
+            credentials = {
+                'id': username,
+                'key': password,
+                'algorithm': 'sha256'
+            }
+            return HawkAuth(credentials=credentials)
 
 except ImportError:
     pass

--- a/requests_hawk/__init__.py
+++ b/requests_hawk/__init__.py
@@ -19,6 +19,11 @@ class HawkAuth(AuthBase):
       You don't need to set this parameter if you already know the hawk
       credentials (Optional).
 
+    :param algorithm:
+      A string containing the name of the algorithm to be used.
+      Currently only applies if passing `hawk_session`.
+      (Optional, defaults to 'sha256').
+
     :param credentials:
       Python dict containing credentials information, with keys for "id",
       "key" and "algorithm" (Optional).
@@ -33,8 +38,8 @@ class HawkAuth(AuthBase):
     exclusive.  You should set one or the other.
 
     """
-    def __init__(self, hawk_session=None, credentials=None, server_url=None,
-                 _timestamp=None):
+    def __init__(self, hawk_session=None, algorithm='sha256',
+                 credentials=None, server_url=None, _timestamp=None):
         if (hawk_session and credentials
                 or not hawk_session and not credentials):
             raise AttributeError("You should pass either 'hawk_session' "
@@ -47,10 +52,12 @@ class HawkAuth(AuthBase):
                 raise TypeError(e)
             keyInfo = 'identity.mozilla.com/picl/v1/sessionToken'
             keyMaterial = HKDF(hawk_session, "", keyInfo, 32*2)
-            credentials = {
-                'id': codecs.encode(keyMaterial[:32], "hex_codec"),
-                'key': codecs.encode(keyMaterial[32:64], "hex_codec"),
-                'algorithm': 'sha256'
+            id = codecs.encode(keyMaterial[:32], "hex_codec")
+            key = codecs.encode(keyMaterial[32:64], "hex_codec")
+            self.credentials = {
+                'id': id,
+                'key': key,
+                'algorithm': algorithm
             }
 
         self.credentials = credentials

--- a/requests_hawk/__init__.py
+++ b/requests_hawk/__init__.py
@@ -25,7 +25,7 @@ class HawkAuth(AuthBase):
 
     :param server_url:
       The url of the server, this is useful for hawk when signing the requests.
-      In case this is omited, fallbacks to the value of the "Host" header of
+      In case this is omitted, fallbacks to the value of the "Host" header of
       the request (Optional).
 
 

--- a/requests_hawk/__init__.py
+++ b/requests_hawk/__init__.py
@@ -35,12 +35,12 @@ class HawkAuth(AuthBase):
     """
     def __init__(self, hawk_session=None, credentials=None, server_url=None,
                  _timestamp=None):
-        if ((credentials, hawk_session) == (None, None)
-                or (credentials is not None and hawk_session is not None)):
+        if (hawk_session and credentials
+                or not hawk_session and not credentials):
             raise AttributeError("You should pass either 'hawk_session' "
                                  "or 'credentials'.")
 
-        elif hawk_session is not None:
+        if hawk_session:
             try:
                 hawk_session = codecs.decode(hawk_session, 'hex_codec')
             except binascii.Error as e:
@@ -52,6 +52,7 @@ class HawkAuth(AuthBase):
                 'key': codecs.encode(keyMaterial[32:64], "hex_codec"),
                 'algorithm': 'sha256'
             }
+
         self.credentials = credentials
         self._timestamp = _timestamp
         self.host = urlparse(server_url).netloc if server_url else None

--- a/requests_hawk/__init__.py
+++ b/requests_hawk/__init__.py
@@ -119,14 +119,14 @@ try:
         auth_type = 'hawk'
         description = ''
 
-        def get_auth(self, id, key):
+        def get_auth(self, username, password):
             kwargs = {}
-            if key == '':
-                kwargs['hawk_session'] = id
+            if password == '':
+                kwargs['hawk_session'] = username
             else:
                 kwargs['credentials'] = {
-                    'id': id,
-                    'key': key,
+                    'id': username,
+                    'key': password,
                     'algorithm': 'sha256'
                 }
             return HawkAuth(**kwargs)

--- a/requests_hawk/tests/test_hawkauth.py
+++ b/requests_hawk/tests/test_hawkauth.py
@@ -6,20 +6,32 @@ from requests_hawk import HawkAuth
 
 class TestHawkAuth(unittest.TestCase):
 
-    def test_hawkauth_errors_when_credentials_and_hawk_session_passed(self):
+    def test_hawkauth_errors_when_id_and_key_and_hawk_session_passed(self):
         self.assertRaises(AttributeError, HawkAuth,
-                          credentials={}, hawk_session="test")
+                          id='test', key='test', hawk_session="test")
+
+    def test_hawkauth_errors_when_id_and_hawk_session_passed(self):
+        self.assertRaises(AttributeError, HawkAuth,
+                          id='test', hawk_session="test")
+
+    def test_hawkauth_errors_when_key_and_hawk_session_passed(self):
+        self.assertRaises(AttributeError, HawkAuth,
+                          key='test', hawk_session="test")
+
+    def test_hawkauth_errors_when_only_id_passed(self):
+        self.assertRaises(AttributeError, HawkAuth, id='test')
+
+    def test_hawkauth_errors_when_only_key_passed(self):
+        self.assertRaises(AttributeError, HawkAuth, key='test')
+
+    def test_hawkauth_errors_when_credentials_passed(self):
+        self.assertRaises(AttributeError, HawkAuth, credentials={})
 
     def test_hawkauth_errors_when_no_auth_is_set(self):
         self.assertRaises(AttributeError, HawkAuth)
 
-    def test_hawk_auth_supports_credentials_as_dict(self):
-        credentials = {
-            'id': 'test_id',
-            'key': 'test_key',
-            'algorithm': 'sha256'
-        }
-        auth = HawkAuth(credentials=credentials, _timestamp=1431698426)
+    def test_hawk_auth_supports_credentials_as_parameters(self):
+        auth = HawkAuth(id='test_id', key='test_key', _timestamp=1431698426)
         request = Request('PUT', 'http://www.example.com',
                           json={"foo": "bar"}, auth=auth)
         r = request.prepare()
@@ -31,6 +43,10 @@ class TestHawkAuth(unittest.TestCase):
         self.assertTrue('ts="1431698426"' in auth_header,
                         "Timestamp doesn't match")
         self.assertEqual(r.body, '{"foo": "bar"}')
+
+    def test_overriding_credentials_algorithm(self):
+        auth = HawkAuth(id='test_id', key='test_key', algorithm='sha1')
+        self.assertEqual(auth.credentials['algorithm'], 'sha1')
 
     def test_key_non_hex_values_throws(self):
         self.assertRaises(TypeError, HawkAuth, hawk_session="test")

--- a/requests_hawk/tests/test_hawkauth.py
+++ b/requests_hawk/tests/test_hawkauth.py
@@ -45,6 +45,11 @@ class TestHawkAuth(unittest.TestCase):
             'algorithm': 'sha256'
         })
 
+    def test_overriding_session_algorithm(self):
+        auth = HawkAuth(hawk_session=codecs.encode(b"hello", "hex_codec"),
+                        algorithm='sha1')
+        self.assertEqual(auth.credentials['algorithm'], 'sha1')
+
     def test_server_url_is_parsed(self):
         auth = HawkAuth(hawk_session=codecs.encode(b"hello", "hex_codec"),
                         server_url="http://localhost:5000")

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,7 @@ create-wheel = yes
 
 [bdist_wheel]
 universal = 1
+
+[flake8]
+# Override the default of 80 characters
+max-line-length = 90

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with codecs.open(os.path.join(here, 'CHANGES.txt'), encoding='utf-8') as f:
 requires = ['requests!=2.8.0', 'mohawk']
 
 setup(name='requests-hawk',
-      version='0.3.0.dev0',
+      version='1.0.0.dev0',
       description='requests-hawk',
       long_description=README + '\n\n' + CHANGES,
       classifiers=[


### PR DESCRIPTION
Previously a `credentials` dict would have to have been constructed, that contained the `id`, `key`, and `algorithm` - that could then be passed to the `HawkAuth` constructor. However a dict is less user-friendly than just passing the parameters directly - and the algorithm rarely varied in practice, so it makes more sense for that to have a default.

As such, the `HawkAuth` constructor has been changed to accept `id` and `key` parameters, and the existing `credentials` parameter has been removed. The algorithm defaults to `sha256`, but can be overridden with a new `algorithm` parameter. This parameter also allows overriding the algorithm when deriving the credentials from the hawk session token, which wasn't previously possible.

Passing the `credentials` parameter now results in an exception with migration advice - as such the major version of this package must be bumped for the next release.

There was a bunch of cleanup needed (and/or desirable to keep diffs simpler) prior to these changes - please see the individual commits for clearer diffs and multi-line commit messages with rationale :-)

Fixes #8.