### PR TITLE
Properly render code blocks in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,32 +18,32 @@ Great, how can I use it?
 
 First, you'll need to install it::
 
-  .. code-block:: bash
+.. code-block:: bash
 
-    pip install requests-hawk
+   pip install requests-hawk
 
 Then, in your project, if you know the `id` and `key`, you can use::
 
-  .. code-block:: python
+.. code-block:: python
 
-    import requests
-    from requests_hawk import HawkAuth
+   import requests
+   from requests_hawk import HawkAuth
 
-    hawk_auth = HawkAuth(id='my-hawk-id', key='my-hawk-secret-key')
-    requests.post("https://example.com/url", auth=hawk_auth)
+   hawk_auth = HawkAuth(id='my-hawk-id', key='my-hawk-secret-key')
+   requests.post("https://example.com/url", auth=hawk_auth)
 
 Or if you need to derive them from the hawk session token, instead use::
 
-  .. code-block:: python
+.. code-block:: python
 
-    import requests
-    from requests_hawk import HawkAuth
+   import requests
+   from requests_hawk import HawkAuth
 
-    hawk_auth = HawkAuth(
-        hawk_session=resp.headers['hawk-session-token'],
-        server_url=self.server_url
-    )
-    requests.post("/url", auth=hawk_auth)
+   hawk_auth = HawkAuth(
+       hawk_session=resp.headers['hawk-session-token'],
+       server_url=self.server_url
+   )
+   requests.post("/url", auth=hawk_auth)
 
 In the second example, the ``server_url`` parameter to ``HawkAuth`` was used to
 provide a default host name, to avoid having to repeat it for each request.
@@ -63,14 +63,14 @@ uses the requests library. We've made it simple for you to plug hawk with it.
 
 If you know the id and key, use it like that::
 
-  .. code-block:: bash
+.. code-block:: bash
 
    http POST localhost:5000/registration\
    --auth-type=hawk --auth='id:key'
 
 Or, if you want to use the hawk session token, you can do as follows::
 
-  .. code-block:: bash
+.. code-block:: bash
 
    http POST localhost:5000/registration\
    --auth-type=hawk --auth='c0d8cd2ec579a3599bef60f060412f01f5dc46f90465f42b5c47467481315f51:'
@@ -89,27 +89,27 @@ hawk credentials.
 Do an HKDF derivation on the given session token. You'll need to use the
 following parameters::
 
-  .. code-block:: python
-
-    key_material = HKDF(hawk_session, '', 'identity.mozilla.com/picl/v1/sessionToken', 32*2)
+.. code-block:: python
+   
+   key_material = HKDF(hawk_session, '', 'identity.mozilla.com/picl/v1/sessionToken', 32*2)
 
 The key material you'll get out of the HKDF needs to be separated into two
 parts, the first 32 hex characters are the ``hawk id``, and the next 32 ones are the
 ``hawk key``::
 
-  .. code-block:: python
+.. code-block:: python
 
-    credentials = {
-        'id': keyMaterial[0:32]
-        'key': keyMaterial[32:64]
-        'algorithm': 'sha256'
-    }
+   credentials = {
+       'id': keyMaterial[0:32]
+       'key': keyMaterial[32:64]
+       'algorithm': 'sha256'
+   }
 
 Run tests
 =========
 
 To run test, you can use tox::
 
-  .. code-block:: bash
+.. code-block:: bash
 
-    tox
+   tox


### PR DESCRIPTION
The code blocks were not properly rendered because of the leading whitespaces in the `.. code-block::` directives