### PR TITLE
Add parameter to skip content hashing

### DIFF
--- a/requests_hawk/__init__.py
+++ b/requests_hawk/__init__.py
@@ -8,6 +8,7 @@ from six.moves.urllib.parse import urlparse
 from six import text_type
 
 import mohawk
+from mohawk.base import EmptyValue
 from requests.auth import AuthBase
 
 
@@ -38,7 +39,8 @@ class HawkAuth(AuthBase):
     You should use either `hawk_session` or both `id` and 'key'.
     """
     def __init__(self, hawk_session=None, id=None, key=None, algorithm='sha256',
-                 credentials=None, server_url=None, _timestamp=None):
+                 credentials=None, server_url=None, _timestamp=None,
+                 always_hash_content=True):
         if credentials is not None:
             raise AttributeError("The 'credentials' param has been removed. "
                                  "Pass 'id' and 'key' instead, or '**credentials_dict'.")
@@ -65,6 +67,7 @@ class HawkAuth(AuthBase):
         }
         self._timestamp = _timestamp
         self.host = urlparse(server_url).netloc if server_url else None
+        self.always_hash_content = always_hash_content
 
     def __call__(self, r):
         if self.host is not None:
@@ -74,8 +77,9 @@ class HawkAuth(AuthBase):
             self.credentials,
             r.url,
             r.method,
-            content=r.body or '',
-            content_type=r.headers.get('Content-Type', ''),
+            content=r.body or EmptyValue,
+            content_type=r.headers.get("Content-Type", EmptyValue),
+            always_hash_content=self.always_hash_content,
             _timestamp=self._timestamp
         )
 

--- a/requests_hawk/tests/test_hawkauth.py
+++ b/requests_hawk/tests/test_hawkauth.py
@@ -95,3 +95,9 @@ class TestHawkAuth(unittest.TestCase):
         self.assertTrue('ts="1431698847"' in r.headers['Authorization'],
                         "Timestamp doesn't match")
         self.assertEqual(r.body, b'{"foo": "bar"}')
+
+    def test_hawk_auth_supports_empty_body(self):
+        auth = HawkAuth(id='test_id', key='test_key', always_hash_content=False)
+        request = Request('GET', 'http://www.example.com', auth=auth)
+        r = request.prepare()
+        self.assertNotIn('hash="', r.headers['Authorization'])


### PR DESCRIPTION
Add `always_hash_content` parameter  to skip content hashing. Enables users to control when content shouldn't be hashed which can be useful for either very large content or empty content, e.g. in a GET request.

fixes #24 


Co-Authored-By: Jeremy Mayeres <1524722+jerr0328@users.noreply.github.com>