### PR TITLE
Add app parameter that used in mohawk library

### DIFF
--- a/requests_hawk/__init__.py
+++ b/requests_hawk/__init__.py
@@ -40,7 +40,7 @@ class HawkAuth(AuthBase):
     """
     def __init__(self, hawk_session=None, id=None, key=None, algorithm='sha256',
                  credentials=None, server_url=None, _timestamp=None,
-                 always_hash_content=True):
+                 always_hash_content=True, app=None):
         if credentials is not None:
             raise AttributeError("The 'credentials' param has been removed. "
                                  "Pass 'id' and 'key' instead, or '**credentials_dict'.")
@@ -68,6 +68,7 @@ class HawkAuth(AuthBase):
         self._timestamp = _timestamp
         self.host = urlparse(server_url).netloc if server_url else None
         self.always_hash_content = always_hash_content
+        self.app = app
 
     def __call__(self, r):
         if self.host is not None:
@@ -80,7 +81,8 @@ class HawkAuth(AuthBase):
             content=r.body or EmptyValue,
             content_type=r.headers.get("Content-Type", EmptyValue),
             always_hash_content=self.always_hash_content,
-            _timestamp=self._timestamp
+            _timestamp=self._timestamp,
+            app=self.app
         )
 
         r.headers['Authorization'] = sender.request_header


### PR DESCRIPTION
In my project, this optional parameter ("app") used as mandatory
I checked changes locally and all works well.
Will be good if it parameter is accessible through requests-hawk.
Because for now we use a copy of the requests-hawk and change it locally.